### PR TITLE
changed title and names of project

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "homepage": "https://www.masonpohler.com/pc-wonder-app",
-  "name": "pc-wonder-app",
+  "name": "pc-wonder",
   "version": "0.1.0",
   "private": true,
   "dependencies": {

--- a/public/index.html
+++ b/public/index.html
@@ -26,7 +26,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>PC Wonder</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
Changes to the manifest and package were lost during the process of learning Github Pages deployment. This fix applies the intended changes to the titles and names within the project.